### PR TITLE
Close both internal clients

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -2,12 +2,12 @@ import PollingClient from './PollingClient';
 import EventsClient from './EventsClient';
 
 const EventEmitter = require('events');
-import {InMemoryFeatureStore} from './FeatureStore';
-import {UserBuilder} from './User';
+import { InMemoryFeatureStore } from './FeatureStore';
+import { UserBuilder } from './User';
 import Evaluate from './Evaluate';
 import debug from './debug';
 
-import {ruleMatches, getVariantValue, getVariantSplitKey, calculateHash, featureEvaluation} from './EvaluateHelpers';
+import { ruleMatches, getVariantValue, getVariantSplitKey, calculateHash, featureEvaluation } from './EvaluateHelpers';
 
 export default class Featureflow extends EventEmitter {
     failoverVariants = {};
@@ -45,7 +45,7 @@ export default class Featureflow extends EventEmitter {
             this.eventsClient.registerFeaturesEvent(this.config.withFeatures);
         }
 
-        this.close = new PollingClient(this.config.baseUrl + '/api/sdk/v1/features', this.config, () => {
+        this.pollingClient = new PollingClient(this.config.baseUrl + '/api/sdk/v1/features', this.config, () => {
             debug("client initialized");
             this.isReady = true;
             this.emit('ready');
@@ -72,7 +72,7 @@ export default class Featureflow extends EventEmitter {
         let evaluatedFeatures = {};
         let features = this.config.featureStore.getAll();
         for (let p in features) {
-            if(  features.hasOwnProperty(p) ) {
+            if (features.hasOwnProperty(p)) {
                 let value = this.evaluate(p, user).value();
                 evaluatedFeatures[p] = value;
             }
@@ -108,5 +108,10 @@ export default class Featureflow extends EventEmitter {
             user,
             this.eventsClient
         );
+    }
+
+    close() {
+        this.pollingClient.close();
+        this.eventsClient.close();
     }
 }

--- a/src/EventsClient.js
+++ b/src/EventsClient.js
@@ -50,7 +50,7 @@ export default class EventsClient {
     }
 
     sendQueue() {
-        if(this.queue.length === 0) return;
+        if (this.queue.length === 0) return;
         let sendQueue = this.queue;
         this.queue = [];
 
@@ -62,7 +62,6 @@ export default class EventsClient {
     }
 
     sendEvent(eventType, method, url, json) {
-
         if (this.disabled) {
             return;
         }
@@ -84,9 +83,6 @@ export default class EventsClient {
             }
         })
     }
-
-
-
 
     close() {
         clearInterval(this.interval);

--- a/src/PollingClient.js
+++ b/src/PollingClient.js
@@ -1,58 +1,61 @@
 import request from 'request';
 import debug from './debug';
 
-export default class PollingClient{
-  DEFAULT_TIMEOUT = 5 * 1000;
-  DEFAULT_INTERVAL = 10 * 1000;
-  clientVersion = 'NodeJsClient/0.6.6';
+export default class PollingClient {
+    DEFAULT_TIMEOUT = 5 * 1000;
+    DEFAULT_INTERVAL = 10 * 1000;
+    clientVersion = 'NodeJsClient/0.6.6';
 
-  constructor(url, config, callback){
-    this.url = url;
-    this.apiKey = config.apiKey;
-    this.featureStore = config.featureStore;
-    this.interval = this.DEFAULT_INTERVAL;
-    if (config.interval && config.interval > 5 || config.interval == 0){
-        this.interval = config.interval * 1000
-    }
-    this.timeout = this.DEFAULT_TIMEOUT;
-    this.etag = "";
-
-    this.getFeatures(callback);
-    if(this.interval > 0){
-        const interval = setInterval(this.getFeatures.bind(this), this.interval);
-        return clearInterval.bind(this, interval);
-    } else {
-        debug("Polling interval set to 0. Featureflow will NOT poll for feature changes.");
-    }
-
-  }
-  getFeatures(callback = ()=>{}){
-    request({
-      method: 'get',
-      uri: this.url,
-      timeout: this.timeout,
-      headers: {
-        'Authorization': 'Bearer '+this.apiKey,
-        'If-None-Match': this.etag,
-        'X-Featureflow-Client': this.clientVersion
-      }
-    }, (error, response, body)=>{
-      if (response){
-          if (response.statusCode === 200){
-              this.etag = response.headers['etag'];
-              debug("updating features");
-              this.featureStore.setAll(JSON.parse(body));
-          }
-          else if (response.statusCode >= 400 || error){
-              debug("request for features failed with response status %d", response.statusCode);
-          }
-          callback()
-      }else{
-        if(error.code != null){
-          debug(error.code);
+    constructor(url, config, callback) {
+        this.url = url;
+        this.apiKey = config.apiKey;
+        this.featureStore = config.featureStore;
+        this.pollingInterval = this.DEFAULT_INTERVAL;
+        if (config.interval && config.interval > 5 || config.interval == 0) {
+            this.pollingInterval = config.interval * 1000
         }
-      }
+        this.timeout = this.DEFAULT_TIMEOUT;
+        this.etag = "";
 
-    })
-  }
+        this.getFeatures(callback);
+        if (this.pollingInterval > 0) {
+            this.interval = setInterval(this.getFeatures.bind(this), this.pollingInterval);
+        } else {
+            debug("Polling interval set to 0. Featureflow will NOT poll for feature changes.");
+        }
+
+    }
+    getFeatures(callback = () => { }) {
+        request({
+            method: 'get',
+            uri: this.url,
+            timeout: this.timeout,
+            headers: {
+                'Authorization': 'Bearer ' + this.apiKey,
+                'If-None-Match': this.etag,
+                'X-Featureflow-Client': this.clientVersion
+            }
+        }, (error, response, body) => {
+            if (response) {
+                if (response.statusCode === 200) {
+                    this.etag = response.headers['etag'];
+                    debug("updating features");
+                    this.featureStore.setAll(JSON.parse(body));
+                }
+                else if (response.statusCode >= 400 || error) {
+                    debug("request for features failed with response status %d", response.statusCode);
+                }
+                callback()
+            } else {
+                if (error.code != null) {
+                    debug(error.code);
+                }
+            }
+
+        })
+    }
+
+    close() {
+        clearInterval(this.interval);
+    }
 }


### PR DESCRIPTION
Closes both the polling client and the events client - the latter is left "open" causing Node to block waiting for the interval to be released.

Note this PR uses 4space indentation throughout - the original code is inconsistent ;(
